### PR TITLE
Add MACH_RCV_TIMEOUT to mach_msg options, when attempt to obtain the …

### DIFF
--- a/FBSimulatorControl/HID/FBSimulatorHID.m
+++ b/FBSimulatorControl/HID/FBSimulatorHID.m
@@ -102,7 +102,7 @@
   handshakeHeader->msgh_remote_port = 0;
   handshakeHeader->msgh_local_port = self.registrationPort;
 
-  kern_return_t result = mach_msg(handshakeHeader, MACH_RCV_LARGE | MACH_RCV_MSG, 0x0, size, self.registrationPort, timeout, 0x0);
+  kern_return_t result = mach_msg(handshakeHeader, MACH_RCV_LARGE | MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0x0, size, self.registrationPort, timeout, 0x0);
   if (result != KERN_SUCCESS) {
     free(handshakeHeader);
     return [[FBSimulatorError


### PR DESCRIPTION
…Reply Port for the Simulator.

Without MACH_RCV_TIMEOUT mach_msg will not automatically timed out after the given timeout duration.